### PR TITLE
Implement SIGTERM handling for Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,7 @@ dependencies = [
  "simplelog",
  "tokio",
  "tokio-util",
+ "windows",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ openaction = "1.1.5"
 simplelog = "0.12.2"
 tokio = { version = "1.44.2", features = ["full"] }
 tokio-util = { version = "0.7.15", features = ["full"] }
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.61.3", features = ["Win32_System_LibraryLoader", "Win32_UI_WindowsAndMessaging", "Win32_Graphics_Gdi"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,18 @@ use mirajazz::device::Device;
 use openaction::*;
 use std::{collections::HashMap, process::exit, sync::LazyLock};
 use tokio::sync::{Mutex, RwLock};
+use tokio::task::spawn_blocking;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use watcher::watcher_task;
 
 #[cfg(not(target_os = "windows"))]
 use tokio::signal::unix::{SignalKind, signal};
+
+#[cfg(target_os = "windows")]
+use windows::{
+    Win32::{Foundation::*, System::LibraryLoader::GetModuleHandleA, UI::WindowsAndMessaging::*},
+    core::s,
+};
 
 mod device;
 mod inputs;
@@ -121,10 +128,67 @@ async fn sigterm() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(target_os = "windows")]
 async fn sigterm() -> Result<(), Box<dyn std::error::Error>> {
-    // Future that would never resolve, so select only acts on OpenDeck connection loss
-    // TODO: Proper windows termination handling
-    std::future::pending::<()>().await;
+    spawn_blocking(|| {
+        log::debug!("Creating dummy window to catch messages");
+        let instance = unsafe { GetModuleHandleA(None).unwrap_or_default() };
+        let window_class = s!("__ss550_event_listener");
 
+        unsafe extern "system" fn wnd_proc(
+            hwnd: HWND,
+            msg: u32,
+            wparam: WPARAM,
+            lparam: LPARAM,
+        ) -> LRESULT {
+            match msg {
+                WM_DESTROY => {
+                    log::debug!("Received WM_DESTROY");
+                    unsafe { PostQuitMessage(0) };
+                    LRESULT(0)
+                }
+                WM_ENDSESSION => {
+                    log::debug!("Received WM_ENDSESSION");
+                    unsafe { PostQuitMessage(0) };
+                    LRESULT(0)
+                }
+                _ => unsafe { DefWindowProcA(hwnd, msg, wparam, lparam) },
+            }
+        }
+
+        let wnd_class = WNDCLASSA {
+            hInstance: instance.into(),
+            lpszClassName: window_class,
+            lpfnWndProc: Some(wnd_proc),
+            ..Default::default()
+        };
+
+        unsafe {
+            RegisterClassA(&wnd_class);
+
+            CreateWindowExA(
+                WINDOW_EX_STYLE::default(),
+                window_class,
+                s!("__ss550_dummy_window"),
+                WS_OVERLAPPEDWINDOW,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                None,
+                None,
+                Some(instance.into()),
+                None,
+            )
+            .expect("Failed to create window");
+
+            log::debug!("Starting message loop");
+            let mut msg = MSG::default();
+            while GetMessageA(&mut msg, None, 0, 0).into() {
+                DispatchMessageA(&msg);
+            }
+            log::debug!("Message loop exited. Considering it as a sigterm");
+        }
+    })
+    .await?;
     Ok(())
 }
 


### PR DESCRIPTION
It uses the Win32 API to create a dummy window that listens for system events until it receives either a `WM_DESTROY` or a `WM_ENDSESSION` message