### PR TITLE
feat: improve button handling for faulty hardware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "opendeck-akp153"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "data-url",
  "futures-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opendeck-akp153"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Requires OpenDeck 2.5.0 or newer
 ## Known issues
 
 - All the "old" devices come with the same serial number. You cannot use two of the same devices at the same time (for example a pair of 153R-s), but you can use two different devices at the same time (for example a 153R and a 153E)
+- Some devices might register ghost touches, prefer to use keyup instead of keydown (keyup is filtered and only executed if a keydown was registered before)
 
 ## Building
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "Name": "Ajazz AKP153 / Mirabox HSV293S",
   "Description": "Device support plugin for Ajazz AKP153 (+variants)",
   "Author": "Andrey Viktorov",
-  "Version": "0.7.4",
+  "Version": "0.7.5",
   "PluginUUID": "st.lynx.plugins.opendeck-akp153",
   "CodePathLin": "opendeck-akp153-linux",
   "CodePathMac": "opendeck-akp153-mac",


### PR DESCRIPTION
This improves button handling by requiring a `ButtonDown` before a `ButtonUp` event.

Beta build: https://github.com/kub3let/opendeck-akp153/releases/tag/v0.7.5

ref:
https://github.com/4ndv/opendeck-akp153/issues/3
https://github.com/nekename/OpenDeck/discussions/137