### PR TITLE
Change it a bit so instead of crash on Deck disconnect it waits 2 seconds and retry connecing.

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -3,45 +3,72 @@ use image::load_from_memory_with_format;
 use mirajazz::{device::Device, error::MirajazzError, state::DeviceStateUpdate};
 use openaction::{OUTBOUND_EVENT_MANAGER, SetImageEvent};
 use tokio_util::sync::CancellationToken;
+use std::time::Duration;
 
 use crate::{
     DEVICES, TOKENS,
     inputs::opendeck_to_device,
     mappings::{
-        COL_COUNT, CandidateDevice, ENCODER_COUNT, KEY_COUNT, Kind, ROW_COUNT,
-        get_image_format_for_key,
+        get_image_format_for_key, CandidateDevice, Kind, COL_COUNT, ENCODER_COUNT, KEY_COUNT,
+        ROW_COUNT,
     },
 };
 
-/// Initializes a device and listens for events
 pub async fn device_task(candidate: CandidateDevice, token: CancellationToken) {
-    log::info!("Running device task for {:?}", candidate);
+    log::info!("Running device supervisor for {:?}", candidate);
 
-    // Wrap in a closure so we can use `?` operator
-    let device = async || -> Result<Device, MirajazzError> {
-        let device = connect(&candidate).await?;
+    let mut retry_delay_secs = 2u64;
 
-        device.set_brightness(50).await?;
-        device.clear_all_button_images().await?;
-        device.flush().await?;
-
-        Ok(device)
-    }()
-    .await;
-
-    let device: Device = match device {
-        Ok(device) => device,
-        Err(err) => {
-            handle_error(&candidate.id, err).await;
-
-            log::error!(
-                "Had error during device init, finishing device task: {:?}",
-                candidate
-            );
-
-            return;
+    loop {
+        if token.is_cancelled() {
+            log::info!("Device task cancelled for {:?}", candidate);
+            break;
         }
-    };
+
+        let result = run_device_session(&candidate, token.clone()).await;
+
+        match result {
+            Ok(()) => {
+                if token.is_cancelled() {
+                    break;
+                }
+
+                log::warn!(
+                    "Device session for {} ended unexpectedly, retrying in {}s",
+                    candidate.id,
+                    retry_delay_secs
+                );
+            }
+            Err(err) => {
+                handle_error(&candidate.id, err, false).await;
+                log::warn!(
+                    "Device session for {} crashed, retrying in {}s",
+                    candidate.id,
+                    retry_delay_secs
+                );
+            }
+        }
+
+        tokio::select! {
+            _ = token.cancelled() => break,
+            _ = tokio::time::sleep(Duration::from_secs(retry_delay_secs)) => {}
+        }
+
+        retry_delay_secs = (retry_delay_secs * 2).min(30);
+    }
+
+    let _ = DEVICES.write().await.remove(&candidate.id);
+    log::info!("Device task finished for {:?}", candidate);
+}
+
+async fn run_device_session(
+    candidate: &CandidateDevice,
+    token: CancellationToken,
+) -> Result<(), MirajazzError> {
+    let device = connect(candidate).await?;
+    device.set_brightness(50).await?;
+    device.clear_all_button_images().await?;
+    device.flush().await?;
 
     log::info!("Registering device {}", candidate.id);
     if let Some(outbound) = OUTBOUND_EVENT_MANAGER.lock().await.as_mut() {
@@ -58,44 +85,46 @@ pub async fn device_task(candidate: CandidateDevice, token: CancellationToken) {
             .unwrap();
     }
 
-    DEVICES.write().await.insert(candidate.id.clone(), device);
+    DEVICES
+        .write()
+        .await
+        .insert(candidate.id.clone(), device);
 
-    tokio::select! {
-        _ = device_events_task(&candidate) => {},
-        _ = token.cancelled() => {}
+    let result = tokio::select! {
+        res = device_events_task(candidate) => res,
+        _ = token.cancelled() => Ok(()),
     };
 
-    log::info!("Shutting down device {:?}", candidate);
-
     if let Some(device) = DEVICES.read().await.get(&candidate.id) {
-        device.shutdown().await.ok();
+        let _ = device.shutdown().await;
     }
 
-    log::info!("Device task finished for {:?}", candidate);
+    DEVICES.write().await.remove(&candidate.id);
+
+    result
 }
 
-/// Handles errors, returning true if should continue, returning false if an error is fatal
-pub async fn handle_error(id: &String, err: MirajazzError) -> bool {
+pub async fn handle_error(id: &str, err: MirajazzError, cancel_task: bool) -> bool {
     log::error!("Device {} error: {}", id, err);
 
-    // Some errors are not critical and can be ignored without sending disconnected event
     if matches!(err, MirajazzError::ImageError(_) | MirajazzError::BadData) {
         return true;
     }
 
     log::info!("Deregistering device {}", id);
     if let Some(outbound) = OUTBOUND_EVENT_MANAGER.lock().await.as_mut() {
-        outbound.deregister_device(id.clone()).await.unwrap();
+        let _ = outbound.deregister_device(id.to_string()).await;
     }
 
-    log::info!("Cancelling tasks for device {}", id);
-    if let Some(token) = TOKENS.read().await.get(id) {
-        token.cancel();
+    if cancel_task {
+        log::info!("Cancelling tasks for device {}", id);
+        if let Some(token) = TOKENS.read().await.get(id) {
+            token.cancel();
+        }
     }
 
     log::info!("Removing device {} from the list", id);
     DEVICES.write().await.remove(id);
-
     log::info!("Finished clean-up for {}", id);
 
     false
@@ -114,7 +143,6 @@ pub async fn connect(candidate: &CandidateDevice) -> Result<Device, MirajazzErro
         Ok(device) => Ok(device),
         Err(e) => {
             log::error!("Error while connecting to device: {e}");
-
             Err(e)
         }
     }
@@ -141,7 +169,7 @@ async fn device_events_task(candidate: &CandidateDevice) -> Result<(), MirajazzE
         let updates = match reader.read(None).await {
             Ok(updates) => updates,
             Err(e) => {
-                if !handle_error(&candidate.id, e).await {
+                if !handle_error(&candidate.id, e, false).await {
                     break;
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,12 @@
-use device::{handle_error, handle_set_image};
+use device::{handle_set_image, handle_error};
 use mirajazz::device::Device;
 use openaction::*;
-use std::{collections::HashMap, process::exit, sync::LazyLock};
+use std::{collections::HashMap, sync::LazyLock, time::Duration};
 use tokio::sync::{Mutex, RwLock};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
-use watcher::watcher_task;
 
 #[cfg(not(target_os = "windows"))]
-use tokio::signal::unix::{SignalKind, signal};
+use tokio::signal::unix::{signal, SignalKind};
 
 mod device;
 mod inputs;
@@ -18,26 +17,26 @@ pub static DEVICES: LazyLock<RwLock<HashMap<String, Device>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 pub static TOKENS: LazyLock<RwLock<HashMap<String, CancellationToken>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
-pub static TRACKER: LazyLock<Mutex<TaskTracker>> = LazyLock::new(|| Mutex::new(TaskTracker::new()));
+pub static TRACKER: LazyLock<Mutex<TaskTracker>> =
+    LazyLock::new(|| Mutex::new(TaskTracker::new()));
 
 struct GlobalEventHandler {}
+
 impl openaction::GlobalEventHandler for GlobalEventHandler {
     async fn plugin_ready(
         &self,
         _outbound: &mut openaction::OutboundEventManager,
     ) -> EventHandlerResult {
         let tracker = TRACKER.lock().await.clone();
-
         let token = CancellationToken::new();
-        tracker.spawn(watcher_task(token.clone()));
 
+        tracker.spawn(watcher::watcher_task(token.clone()));
         TOKENS
             .write()
             .await
             .insert("_watcher_task".to_string(), token);
 
         log::info!("Plugin initialized");
-
         Ok(())
     }
 
@@ -48,7 +47,6 @@ impl openaction::GlobalEventHandler for GlobalEventHandler {
     ) -> EventHandlerResult {
         log::debug!("Asked to set image: {:#?}", event);
 
-        // Skip knobs images
         if event.controller == Some("Encoder".to_string()) {
             log::debug!("Looks like a knob, no need to set image");
             return Ok(());
@@ -57,10 +55,11 @@ impl openaction::GlobalEventHandler for GlobalEventHandler {
         let id = event.device.clone();
 
         if let Some(device) = DEVICES.read().await.get(&event.device) {
-            handle_set_image(device, event)
+            let _ = handle_set_image(device, event)
                 .await
-                .map_err(async |err| handle_error(&id, err).await)
-                .ok();
+                .map_err(|err| async {
+                    handle_error(&id, err, false).await;
+                });
         } else {
             log::error!("Received event for unknown device: {}", event.device);
         }
@@ -78,11 +77,12 @@ impl openaction::GlobalEventHandler for GlobalEventHandler {
         let id = event.device.clone();
 
         if let Some(device) = DEVICES.read().await.get(&event.device) {
-            device
+            let _ = device
                 .set_brightness(event.brightness)
                 .await
-                .map_err(async |err| handle_error(&id, err).await)
-                .ok();
+                .map_err(|err| async {
+                    handle_error(&id, err, false).await;
+                });
         } else {
             log::error!("Received event for unknown device: {}", event.device);
         }
@@ -96,40 +96,56 @@ impl openaction::ActionEventHandler for ActionEventHandler {}
 
 async fn shutdown() {
     let tokens = TOKENS.write().await;
-
     for (_, token) in tokens.iter() {
         token.cancel();
     }
 }
 
-async fn connect() {
-    if let Err(error) = init_plugin(GlobalEventHandler {}, ActionEventHandler {}).await {
-        log::error!("Failed to initialize plugin: {}", error);
+async fn cleanup_runtime() {
+    shutdown().await;
 
-        exit(1);
+    let tracker = TRACKER.lock().await.clone();
+    tracker.wait().await;
+
+    TOKENS.write().await.clear();
+    DEVICES.write().await.clear();
+}
+
+async fn connect_loop(stop: CancellationToken) {
+    while !stop.is_cancelled() {
+        match init_plugin(GlobalEventHandler {}, ActionEventHandler {}).await {
+            Ok(_) => {
+                log::warn!("Disconnected from OpenDeck, retrying in 2 seconds");
+            }
+            Err(error) => {
+                log::error!("Failed to initialize plugin: {}", error);
+            }
+        }
+
+        cleanup_runtime().await;
+
+        tokio::select! {
+            _ = stop.cancelled() => break,
+            _ = tokio::time::sleep(Duration::from_secs(2)) => {}
+        }
     }
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-async fn sigterm() -> Result<(), Box<dyn std::error::Error>> {
+async fn sigterm() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut sig = signal(SignalKind::terminate())?;
-
     sig.recv().await;
-
     Ok(())
 }
 
 #[cfg(target_os = "windows")]
-async fn sigterm() -> Result<(), Box<dyn std::error::Error>> {
-    // Future that would never resolve, so select only acts on OpenDeck connection loss
-    // TODO: Proper windows termination handling
+async fn sigterm() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     std::future::pending::<()>().await;
-
     Ok(())
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     simplelog::TermLogger::init(
         simplelog::LevelFilter::Info,
         simplelog::Config::default(),
@@ -138,23 +154,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .unwrap();
 
+    let stop = CancellationToken::new();
+    let stop_for_loop = stop.clone();
+
     tokio::select! {
-        _ = connect() => {},
-        _ = sigterm() => {},
+        _ = connect_loop(stop_for_loop) => {},
+        _ = sigterm() => {
+            log::info!("Received SIGTERM");
+            stop.cancel();
+        }
     }
 
     log::info!("Shutting down");
-
-    shutdown().await;
+    cleanup_runtime().await;
 
     let tracker = TRACKER.lock().await.clone();
-
-    log::info!("Waiting for tasks to finish");
-
     tracker.close();
     tracker.wait().await;
 
     log::info!("Tasks are finished, exiting now");
-
     Ok(())
 }


### PR DESCRIPTION
Replace fatal exit paths with automatic reconnect logic.

Changes:
- add reconnect loop for whole plugin instead of exiting on init failure
- add supervisor loop for device tasks with retry/backoff
- split device session handling from device task supervision
- clean up runtime state before reconnect attempts
- avoid permanently cancelling device task on recoverable device errors
- keep permanent cancellation only for actual device disconnect events

I hope it will work.