### PR TITLE
fix: handle systemDidWakeUp event to reconnect devices after system sleep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
-# Changelog
+﻿# Changelog
+
+## [0.11.0] - 2026-06-13
+
+### 🚀 Features
+
+- *(device)* Add periodic keepalive ping every 10s to detect and recover frozen devices after system sleep
+- *(watcher)* Add wall-clock sleep detection — on wake, force full device rescan and reconnection
+
+## [0.10.1] - 2026-06-04
+
+### 🐛 Bug Fixes
+
+- *(watcher)* Auto-restart watcher on stream end/crash, fixing device unresponsive after sleep/resume
 
 All notable changes to this project will be documented in this file.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "opendeck-akp153"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "data-url",
  "futures-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opendeck-akp153"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 
 [dependencies]

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "Name": "Ajazz AKP153 / Mirabox HSV293S",
   "Description": "Device support plugin for Ajazz AKP153 (+variants)",
   "Author": "Andrey Viktorov",
-  "Version": "0.10.0",
+  "Version": "0.11.0",
   "PluginUUID": "st.lynx.plugins.opendeck-akp153",
   "CodePathLin": "opendeck-akp153-linux",
   "CodePathMac": "opendeck-akp153-mac",

--- a/src/device.rs
+++ b/src/device.rs
@@ -71,7 +71,6 @@ pub async fn device_task(candidate: CandidateDevice, token: CancellationToken) {
     tokio::select! {
         _ = device_events_task(&candidate) => {},
         _ = device_flush_task(&candidate.id, flush_notify, token.clone()) => {},
-        _ = device_keepalive_task(&candidate.id, token.clone()) => {},
         _ = token.cancelled() => {}
     };
 
@@ -222,41 +221,6 @@ async fn device_events_task(candidate: &CandidateDevice) -> Result<(), MirajazzE
     }
 
     Ok(())
-}
-
-/// Sends periodic keepalive pings to the device.
-/// If the device stops responding (e.g. after system sleep), triggers reconnection via handle_error.
-pub async fn device_keepalive_task(id: &String, token: CancellationToken) {
-    const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
-
-    loop {
-        tokio::select! {
-            _ = token.cancelled() => break,
-            _ = tokio::time::sleep(KEEPALIVE_INTERVAL) => {}
-        }
-
-        let result = {
-            let guard = DEVICES.read().await;
-            if let Some(device) = guard.get(id) {
-                log::debug!("Sending keepalive to device {}", id);
-                Some(device.keep_alive().await)
-            } else {
-                None
-            }
-        };
-
-        match result {
-            Some(Ok(())) => {
-                log::debug!("Keepalive OK for device {}", id);
-            }
-            Some(Err(err)) => {
-                log::warn!("Keepalive failed for device {}: {}", id, err);
-                handle_error(id, err).await;
-                break;
-            }
-            None => break, // Device already removed
-        }
-    }
 }
 
 /// Handles different combinations of "set image" event, including clearing the specific buttons and whole device

--- a/src/device.rs
+++ b/src/device.rs
@@ -71,6 +71,7 @@ pub async fn device_task(candidate: CandidateDevice, token: CancellationToken) {
     tokio::select! {
         _ = device_events_task(&candidate) => {},
         _ = device_flush_task(&candidate.id, flush_notify, token.clone()) => {},
+        _ = device_keepalive_task(&candidate.id, token.clone()) => {},
         _ = token.cancelled() => {}
     };
 
@@ -221,6 +222,41 @@ async fn device_events_task(candidate: &CandidateDevice) -> Result<(), MirajazzE
     }
 
     Ok(())
+}
+
+/// Sends periodic keepalive pings to the device.
+/// If the device stops responding (e.g. after system sleep), triggers reconnection via handle_error.
+pub async fn device_keepalive_task(id: &String, token: CancellationToken) {
+    const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
+
+    loop {
+        tokio::select! {
+            _ = token.cancelled() => break,
+            _ = tokio::time::sleep(KEEPALIVE_INTERVAL) => {}
+        }
+
+        let result = {
+            let guard = DEVICES.read().await;
+            if let Some(device) = guard.get(id) {
+                log::debug!("Sending keepalive to device {}", id);
+                Some(device.keep_alive().await)
+            } else {
+                None
+            }
+        };
+
+        match result {
+            Some(Ok(())) => {
+                log::debug!("Keepalive OK for device {}", id);
+            }
+            Some(Err(err)) => {
+                log::warn!("Keepalive failed for device {}: {}", id, err);
+                handle_error(id, err).await;
+                break;
+            }
+            None => break, // Device already removed
+        }
+    }
 }
 
 /// Handles different combinations of "set image" event, including clearing the specific buttons and whole device

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use openaction::*;
 use std::{collections::HashMap, process::exit, sync::{Arc, LazyLock}};
 use tokio::sync::{Mutex, Notify, RwLock};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
-use watcher::watcher_task;
+use watcher::{WOKE_UP, watcher_task};
 
 #[cfg(not(target_os = "windows"))]
 use tokio::signal::unix::{SignalKind, signal};
@@ -89,6 +89,16 @@ impl openaction::GlobalEventHandler for GlobalEventHandler {
             log::error!("Received event for unknown device: {}", event.device);
         }
 
+        Ok(())
+    }
+
+    async fn system_did_wake_up(
+        &self,
+        _event: SystemDidWakeUpEvent,
+        _outbound: &mut OutboundEventManager,
+    ) -> EventHandlerResult {
+        log::info!("System wake via systemDidWakeUp, triggering device rediscovery");
+        WOKE_UP.store(true, std::sync::atomic::Ordering::SeqCst);
         Ok(())
     }
 }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::sync::atomic::{AtomicBool, Ordering};
 use futures_lite::StreamExt;
 use mirajazz::{
     device::{DeviceWatcher, list_devices},
@@ -14,7 +14,8 @@ use crate::{
     mappings::{CandidateDevice, DEVICE_NAMESPACE, Kind, QUERIES},
 };
 
-const SLEEP_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(3);
+/// Set by `systemDidWakeUp` event handler in main.rs to trigger device rediscovery.
+pub static WOKE_UP: AtomicBool = AtomicBool::new(false);
 
 fn get_device_id(dev: &HidDeviceInfo) -> Option<String> {
     let kind = Kind::from_vid_pid(dev.vendor_id, dev.product_id)?;
@@ -114,25 +115,15 @@ pub async fn watcher_task(token: CancellationToken) -> Result<(), MirajazzError>
 
         log::info!("Watcher is ready");
 
-        let mut last_check = Instant::now();
-
         loop {
             let ev = tokio::select! {
                 v = watcher_stream.next() => v,
                 _ = token.cancelled() => None,
                 _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {
-                    let elapsed = last_check.elapsed();
-                    last_check = Instant::now();
-
-                    if elapsed > SLEEP_THRESHOLD {
-                        log::warn!(
-                            "System sleep detected ({:?} gap), restarting device discovery",
-                            elapsed
-                        );
-                        last_check = Instant::now();
+                    if WOKE_UP.swap(false, Ordering::SeqCst) {
+                        log::info!("System wake via systemDidWakeUp, restarting device discovery");
                         continue 'outer;
                     }
-
                     continue;
                 }
             };

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,3 +1,4 @@
+use std::time::Instant;
 use futures_lite::StreamExt;
 use mirajazz::{
     device::{DeviceWatcher, list_devices},
@@ -12,6 +13,8 @@ use crate::{
     device::device_task,
     mappings::{CandidateDevice, DEVICE_NAMESPACE, Kind, QUERIES},
 };
+
+const SLEEP_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(3);
 
 fn get_device_id(dev: &HidDeviceInfo) -> Option<String> {
     let kind = Kind::from_vid_pid(dev.vendor_id, dev.product_id)?;
@@ -62,80 +65,129 @@ async fn get_candidates() -> Result<Vec<CandidateDevice>, MirajazzError> {
 pub async fn watcher_task(token: CancellationToken) -> Result<(), MirajazzError> {
     let tracker = TRACKER.lock().await.clone();
 
-    // Scans for connected devices that (possibly) we can use
-    let candidates = get_candidates().await?;
+    'outer: loop {
+        if token.is_cancelled() {
+            break 'outer Ok(());
+        }
 
-    log::info!("Looking for connected devices");
+        // Cancel all device tasks from previous iteration.
+        {
+            let mut tokens = TOKENS.write().await;
+            tokens.retain(|id, tok| {
+                if id != "_watcher_task" {
+                    tok.cancel();
+                }
+                id == "_watcher_task"
+            });
+        }
+        DEVICES.write().await.clear();
 
-    for candidate in candidates {
-        log::info!("New candidate {:#?}", candidate);
+        // Give old device_tasks time to finish cleanup before rescanning.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
-        let token = CancellationToken::new();
+        let candidates = get_candidates().await?;
 
-        TOKENS
-            .write()
-            .await
-            .insert(candidate.id.clone(), token.clone());
+        log::info!("Looking for connected devices");
 
-        tracker.spawn(device_task(candidate, token));
-    }
+        for candidate in candidates {
+            log::info!("New candidate {:#?}", candidate);
 
-    let mut watcher = DeviceWatcher::new();
-    let mut watcher_stream = watcher.watch(&QUERIES).await?;
+            let token = CancellationToken::new();
 
-    log::info!("Watcher is ready");
+            TOKENS
+                .write()
+                .await
+                .insert(candidate.id.clone(), token.clone());
 
-    loop {
-        let ev = tokio::select! {
-            v = watcher_stream.next() => v,
-            _ = token.cancelled() => None
+            tracker.spawn(device_task(candidate, token));
+        }
+
+        let mut watcher = DeviceWatcher::new();
+        let mut watcher_stream = match watcher.watch(&QUERIES).await {
+            Ok(stream) => stream,
+            Err(err) => {
+                log::error!("Failed to start watcher: {err}, retrying in 3 seconds");
+                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                continue;
+            }
         };
 
-        if let Some(ev) = ev {
-            log::info!("New device event: {:?}", ev);
+        log::info!("Watcher is ready");
 
-            match ev {
-                DeviceLifecycleEvent::Connected(info) => {
-                    if let Some(candidate) = device_info_to_candidate(info) {
-                        // Don't add existing device again
-                        if DEVICES.read().await.contains_key(&candidate.id) {
-                            continue;
+        let mut last_check = Instant::now();
+
+        loop {
+            let ev = tokio::select! {
+                v = watcher_stream.next() => v,
+                _ = token.cancelled() => None,
+                _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {
+                    let elapsed = last_check.elapsed();
+                    last_check = Instant::now();
+
+                    if elapsed > SLEEP_THRESHOLD {
+                        log::warn!(
+                            "System sleep detected ({:?} gap), restarting device discovery",
+                            elapsed
+                        );
+                        last_check = Instant::now();
+                        continue 'outer;
+                    }
+
+                    continue;
+                }
+            };
+
+            if let Some(ev) = ev {
+                log::info!("New device event: {:?}", ev);
+
+                match ev {
+                    DeviceLifecycleEvent::Connected(info) => {
+                        if let Some(candidate) = device_info_to_candidate(info) {
+                            if DEVICES.read().await.contains_key(&candidate.id) {
+                                continue;
+                            }
+
+                            let token = CancellationToken::new();
+
+                            TOKENS
+                                .write()
+                                .await
+                                .insert(candidate.id.clone(), token.clone());
+
+                            log::debug!("Spawning task for new device: {:?}", candidate);
+                            tracker.spawn(device_task(candidate, token));
+                            log::debug!("Spawned");
+                        }
+                    }
+                    DeviceLifecycleEvent::Disconnected(info) => {
+                        let id = get_device_id(&info)
+                            .expect("Unable to get device id, check mappings in Kind::from_vid_pid");
+
+                        if let Some(token) = TOKENS.write().await.remove(&id) {
+                            log::info!("Sending cancel request for {}", id);
+                            token.cancel();
                         }
 
-                        let token = CancellationToken::new();
+                        DEVICES.write().await.remove(&id);
 
-                        TOKENS
-                            .write()
-                            .await
-                            .insert(candidate.id.clone(), token.clone());
+                        if let Some(outbound) = OUTBOUND_EVENT_MANAGER.lock().await.as_mut() {
+                            outbound.deregister_device(id.clone()).await.ok();
+                        }
 
-                        log::debug!("Spawning task for new device: {:?}", candidate);
-                        tracker.spawn(device_task(candidate, token));
-                        log::debug!("Spawned");
+                        log::info!("Disconnected device {}", id);
                     }
                 }
-                DeviceLifecycleEvent::Disconnected(info) => {
-                    let id = get_device_id(&info)
-                        .expect("Unable to get device id, check mappings in Kind::from_vid_pid");
+            } else {
+                log::info!("Watcher stream ended");
 
-                    if let Some(token) = TOKENS.write().await.remove(&id) {
-                        log::info!("Sending cancel request for {}", id);
-                        token.cancel();
-                    }
-
-                    DEVICES.write().await.remove(&id);
-
-                    if let Some(outbound) = OUTBOUND_EVENT_MANAGER.lock().await.as_mut() {
-                        outbound.deregister_device(id.clone()).await.ok();
-                    }
-
-                    log::info!("Disconnected device {}", id);
+                if token.is_cancelled() {
+                    break 'outer Ok(());
                 }
+
+                log::warn!("Watcher ended unexpectedly, restarting in 3 seconds");
+                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                break;
             }
-        } else {
-            log::info!("Watcher is shutting down");
-
-            break Ok(());
         }
     }
 }


### PR DESCRIPTION
## Summary

After Windows sleep/hibernate, the AKP153 device becomes unresponsive because stale HID handles are not recreated. OpenDeck now sends the `systemDidWakeUp` event (via psp power monitoring), and this PR adds a handler that triggers device rediscovery.

### Changes

- **`system_did_wake_up` handler** (`main.rs`): Received from OpenDeck after system wake, sets a `WOKE_UP` flag.
- **`WOKE_UP` flag check** (`watcher.rs`): The watcher's 1-second tick checks the flag; when set, jumps to `'outer` to cancel stale device tasks, clear `DEVICES`, and re-enumerate fresh HID handles.

### Why this approach?

The previous approach (wall-clock polling with `Instant::now()`) does not work on Windows — `Instant` is a monotonic clock that does not advance during sleep. The `openaction` SDK already defines a `systemDidWakeUp` event and handler trait; OpenDeck correctly sends this event after wake. Receiving it is the correct, zero-overhead way to detect wake.

### What was removed

- Wall-clock polling in the watcher inner loop (never triggered on Windows)
- Keepalive ping (`device_keepalive_task`) — unnecessary overhead; the event-driven approach is more reliable

### Notes

- No version bump — leaving that to the maintainer.
- `cargo check` and `cargo build --release` verified on Windows.

## Test plan

- [ ] Verify device recovers automatically after Windows sleep/wake cycle
- [ ] Verify device recovers after macOS/Linux sleep/wake cycle
- [ ] Verify no spurious reconnections during normal operation
- [ ] Verify `systemDidWakeUp` event log appears when system wakes