### PR TITLE
fix(hsv293s): preserve explicit press/release states

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -8,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     DEVICES, FLUSH_NOTIFY, TOKENS,
-    inputs::opendeck_to_device,
+    inputs::{opendeck_to_device, process_hsv293s_report},
     mappings::{
         COL_COUNT, CandidateDevice, ENCODER_COUNT, KEY_COUNT, Kind, ROW_COUNT,
         get_image_format_for_key,
@@ -180,10 +180,24 @@ async fn device_events_task(candidate: &CandidateDevice) -> Result<(), MirajazzE
 
     log::info!("Reader is ready for {}", candidate.id);
 
+    // HSV293S reports one key per packet. Keep an independent snapshot so the
+    // patched firmware's data[10] flag can produce real key-down/key-up events
+    // without breaking simultaneous holds.
+    let mut hsv293s_button_states = vec![false; KEY_COUNT];
+
     loop {
         log::info!("Reading updates...");
 
-        let updates = match reader.read(None).await {
+        let updates_result = if matches!(&candidate.kind, Kind::HSV293S) {
+            match reader.raw_read_data(512).await {
+                Ok(data) => process_hsv293s_report(&data, &mut hsv293s_button_states),
+                Err(err) => Err(err),
+            }
+        } else {
+            reader.read(None).await
+        };
+
+        let updates = match updates_result {
             Ok(updates) => updates,
             Err(e) => {
                 if !handle_error(&candidate.id, e).await {

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -1,4 +1,4 @@
-use mirajazz::{error::MirajazzError, types::DeviceInput};
+use mirajazz::{error::MirajazzError, state::DeviceStateUpdate, types::DeviceInput};
 
 use crate::mappings::KEY_COUNT;
 
@@ -60,4 +60,116 @@ fn read_button_press(input: u8, state: u8) -> Result<DeviceInput, MirajazzError>
     Ok(DeviceInput::ButtonStateChange(read_button_states(
         &button_states,
     )))
+}
+
+/// Processes the extended press/release reports emitted by patched HSV293S
+/// firmware while remaining compatible with stock release-only firmware.
+///
+/// This is deliberately stateful: each HSV293S packet describes one key, not
+/// the complete keyboard. Keeping the state here prevents pressing a second
+/// key from implicitly releasing the first one.
+pub fn process_hsv293s_report(
+    data: &[u8],
+    button_states: &mut [bool],
+) -> Result<Vec<DeviceStateUpdate>, MirajazzError> {
+    const BUTTON_REPORT_PREFIX: [u8; 9] = [0x41, 0x43, 0x4b, 0x00, 0x00, 0x4f, 0x4b, 0x00, 0x00];
+
+    if data.len() < 11 || !data.starts_with(&BUTTON_REPORT_PREFIX) {
+        return Ok(vec![]);
+    }
+
+    let input = data[9];
+    if input == 0 {
+        return Ok(vec![]);
+    }
+    if input as usize > KEY_COUNT || data[10] > 1 {
+        return Err(MirajazzError::BadData);
+    }
+
+    let key = device_to_opendeck(input as usize);
+    let Some(current_state) = button_states.get_mut(key) else {
+        return Err(MirajazzError::BadData);
+    };
+
+    match (data[10], *current_state) {
+        // Patched firmware: a real key-down packet.
+        (1, false) => {
+            *current_state = true;
+            Ok(vec![DeviceStateUpdate::ButtonDown(key as u8)])
+        }
+        // Patched firmware: release the key that is currently held.
+        (0, true) => {
+            *current_state = false;
+            Ok(vec![DeviceStateUpdate::ButtonUp(key as u8)])
+        }
+        // Stock firmware only reports a zero-state packet on release. Preserve
+        // the old click behaviour when no preceding key-down was observed.
+        (0, false) => Ok(vec![
+            DeviceStateUpdate::ButtonDown(key as u8),
+            DeviceStateUpdate::ButtonUp(key as u8),
+        ]),
+        // Ignore a duplicate down report.
+        (1, true) => Ok(vec![]),
+        _ => unreachable!(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(input: u8, state: u8) -> [u8; 512] {
+        let mut data = [0u8; 512];
+        data[..9].copy_from_slice(&[0x41, 0x43, 0x4b, 0x00, 0x00, 0x4f, 0x4b, 0x00, 0x00]);
+        data[9] = input;
+        data[10] = state;
+        data
+    }
+
+    #[test]
+    fn emits_distinct_down_and_up_for_patched_firmware() {
+        let mut states = vec![false; KEY_COUNT];
+
+        assert!(matches!(
+            process_hsv293s_report(&report(1, 1), &mut states).unwrap()[..],
+            [DeviceStateUpdate::ButtonDown(4)]
+        ));
+        assert!(matches!(
+            process_hsv293s_report(&report(1, 0), &mut states).unwrap()[..],
+            [DeviceStateUpdate::ButtonUp(4)]
+        ));
+    }
+
+    #[test]
+    fn preserves_other_held_keys() {
+        let mut states = vec![false; KEY_COUNT];
+
+        process_hsv293s_report(&report(1, 1), &mut states).unwrap();
+        assert!(matches!(
+            process_hsv293s_report(&report(2, 1), &mut states).unwrap()[..],
+            [DeviceStateUpdate::ButtonDown(10)]
+        ));
+        assert!(states[4]);
+        assert!(states[10]);
+
+        assert!(matches!(
+            process_hsv293s_report(&report(1, 0), &mut states).unwrap()[..],
+            [DeviceStateUpdate::ButtonUp(4)]
+        ));
+        assert!(!states[4]);
+        assert!(states[10]);
+    }
+
+    #[test]
+    fn keeps_stock_release_only_firmware_compatible() {
+        let mut states = vec![false; KEY_COUNT];
+
+        assert!(matches!(
+            process_hsv293s_report(&report(1, 0), &mut states).unwrap()[..],
+            [
+                DeviceStateUpdate::ButtonDown(4),
+                DeviceStateUpdate::ButtonUp(4)
+            ]
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

- read HSV293S button reports directly so an explicit state byte can produce separate key-down and key-up events
- preserve stock release-only behavior by synthesizing a click when no preceding key-down was observed
- maintain independent button state so simultaneous holds do not release each other
- add tests for press/release reports, stock release-only reports, and simultaneous holds

## Why

`mirajazz` treats protocol-v1 devices as release-only: it replaces the report
state with `1` and emits a down/up pair for every packet. When HSV293S firmware
exposes both transition packets using `data[10]`, one physical click is therefore
emitted twice.

The HSV293S-specific reader keeps the existing behavior for stock firmware while
allowing real key-down/key-up events when the state byte is available.

## Tested

- `cargo test --locked`
- physical AKP153R cross-flashed to HSV293S V2.293S.00.003 with press/release-capable firmware
