### PR TITLE
feat: add support for Monstargear MonstarDeck TS115 (0400:1000)

### DIFF
--- a/40-opendeck-akp153.rules
+++ b/40-opendeck-akp153.rules
@@ -12,6 +12,7 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="0a00", ATTRS{idProduct}=="1001", MODE="0660"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0500", ATTRS{idProduct}=="1001", MODE="0660", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1500", ATTRS{idProduct}=="3003", MODE="0660", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0600", ATTRS{idProduct}=="1000", MODE="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0400", ATTRS{idProduct}=="1000", MODE="0660", TAG+="uaccess"
 
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="6603", ATTRS{idProduct}=="1014", MODE="0660", TAG+="uaccess"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="6603", ATTRS{idProduct}=="1005", MODE="0660", TAG+="uaccess"
@@ -27,3 +28,4 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0a00", ATTRS{idProduct
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0500", ATTRS{idProduct}=="1001", MODE="0660", TAG+="uaccess"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1500", ATTRS{idProduct}=="3003", MODE="0660", TAG+="uaccess"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0600", ATTRS{idProduct}=="1000", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0400", ATTRS{idProduct}=="1000", MODE="0660", TAG+="uaccess"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Requires OpenDeck 2.5.0 or newer
 - Soomfon Stream Controller XF-CN001 (1500:3003)
 - Soomfon Studio Control Deck (5548:6670) (would be displayed as Mirabox HSV293S)
 - Womier D15 (0600:1000)
+- Monstargear MonstarDeck TS115 (0400:1000)
 
 ## Platform support
 

--- a/src/mappings.rs
+++ b/src/mappings.rs
@@ -28,6 +28,7 @@ pub enum Kind {
     SFSTC,
     TMICESC,
     D15,
+    TS115,
 }
 
 pub const AJAZZ_VID: u16 = 0x0300;
@@ -39,6 +40,7 @@ pub const RISEMODE_VID: u16 = 0x0a00;
 pub const SF_STC_VID: u16 = 0x1500;
 pub const TMICE_VID: u16 = 0x0500;
 pub const WOMIER_VID: u16 = 0x0600;
+pub const MONSTARGEAR_VID: u16 = 0x0400;
 
 pub const HSV293S_PID: u16 = 0x6670;
 pub const HSV293SV3_PID: u16 = 0x1014;
@@ -60,6 +62,8 @@ pub const TMICESC_PID: u16 = 0x1001;
 
 pub const D15_PID: u16 = 0x1000;
 
+pub const TS115_PID: u16 = 0x1000;
+
 // Map all queries to usage page 65440 and usage id 1 for now
 pub const HSV293S_QUERY: DeviceQuery = DeviceQuery::new(65440, 1, MIRABOX_VID, HSV293S_PID);
 pub const HSV293SV3_QUERY: DeviceQuery = DeviceQuery::new(65440, 1, MIRABOX_2_VID, HSV293SV3_PID);
@@ -76,8 +80,9 @@ pub const RMV01_QUERY: DeviceQuery = DeviceQuery::new(65440, 1, RISEMODE_VID, RM
 pub const SF_STC_QUERY: DeviceQuery = DeviceQuery::new(65440, 1, SF_STC_VID, SF_STC_PID);
 pub const TMICESC_QUERY: DeviceQuery = DeviceQuery::new(65440, 1, TMICE_VID, TMICESC_PID);
 pub const D15_QUERY: DeviceQuery = DeviceQuery::new(65440, 1, WOMIER_VID, D15_PID);
+pub const TS115_QUERY: DeviceQuery = DeviceQuery::new(65440, 1, MONSTARGEAR_VID, TS115_PID);
 
-pub const QUERIES: [DeviceQuery; 14] = [
+pub const QUERIES: [DeviceQuery; 15] = [
     HSV293S_QUERY,
     HSV293SV3_QUERY,
     HSV293SV3_1005_QUERY,
@@ -92,6 +97,7 @@ pub const QUERIES: [DeviceQuery; 14] = [
     SF_STC_QUERY,
     TMICESC_QUERY,
     D15_QUERY,
+    TS115_QUERY,
 ];
 
 /// Returns correct image format for device kind and key
@@ -172,6 +178,11 @@ impl Kind {
                 _ => None,
             },
 
+            MONSTARGEAR_VID => match pid {
+                TS115_PID => Some(Kind::TS115),
+                _ => None,
+            },
+
             _ => None,
         }
     }
@@ -205,6 +216,7 @@ impl Kind {
             Self::SFSTC => "Soomfon Stream Controller",
             Self::TMICESC => "TMICE Stream Controller",
             Self::D15 => "Womier D15",
+            Self::TS115 => "Monstargear MonstarDeck TS115",
         }
         .to_string()
     }
@@ -222,6 +234,7 @@ impl Kind {
             Self::RMV01 => "RMV01",
             Self::TMICESC => "TMICESC",
             Self::D15 => "D15",
+            Self::TS115 => "TS115",
             // This method would not be called for "v2"/"v3" devices, so mark them as unreachable
             Self::HSV293SV3 => unreachable!(),
             Self::HSV293SV3_1005 => unreachable!(),


### PR DESCRIPTION
## Summary

Adds `Kind::TS115` for the Monstargear MonstarDeck TS115, a Korean-market rebrand of the Mirabox HSV293S. It uses a previously unregistered VID (`0x0400`) with the familiar `0x1000` PID, matching the pattern of the Mars Gaming / Mad Dog / Womier variants already supported.

No protocol changes were needed — the device works with the existing protocol version 1 path.

## Device identification

The firmware identifies itself as `V2.293S.00.003` (read via feature report `0x01`), which places it in the HSV293S family.

USB descriptor:

```
idVendor       0x0400
idProduct      0x1000
iManufacturer  "A53"
iProduct       "A53FF"
bcdDevice      3.00
```

The USB ID database misreports `0400:1000` as a Mustek scanner, so `lsusb` output for this device is misleading.

## Protocol compatibility

HID report descriptor matches the family signature:

- Usage page `0xFFA0`, usage id `1` (same as `DeviceQuery::new(65440, 1, ...)`)
- Input report: 512 bytes, no report ID
- Output report: 512 bytes, no report ID
- Single interface, interrupt IN `0x82` / interrupt OUT `0x01`

Confirmed working against the existing implementation:

- `CRT` + `DIS` / `LIG` / `BAT` / `STP` commands are all accepted
- Input reports arrive with the `ACK` prefix, key index at offset 9
- 513-byte writes (1 report ID byte + 512 payload) transfer with `status=0` on the bus
- Key image format JPEG 85x85 / Rot90 / MirrorBoth renders correctly
- 18 keys (15 LCD + 3 side panels), same as the AKP153 layout

The AKP153 index mapping applies unchanged. Verified by pressing keys left-to-right, top-to-bottom:

| device index | 13 | 10 | 7 | 4 | 1 | 3 |
|---|---|---|---|---|---|---|
| normalized key | 0 | 1 | 2 | 3 | 4 | 16 |

## Note on input activation

On this unit, the device does not emit any input reports until at least one key image has been written. Sending only `DIS`, `LIG`, `CONNECT` or `MOD` leaves the interrupt IN endpoint silent — verified with usbmon: the IN URB stays submitted and uncompleted while OUT transfers succeed. Once `BAT` + image data + `STP` completes, key events start arriving immediately.

This has no practical impact in OpenDeck, since images are always pushed on connect. I have not tested whether other devices in this family behave the same way, so this may not be TS115-specific.

## Testing

Ubuntu 24.04, kernel 7.0.0-28, OpenDeck 2.14.0.

Device is detected, all 18 keys render images, and key presses produce correct ButtonDown/ButtonUp events. Hotplug reconnect works.

## Changes

- `src/mappings.rs`: `MONSTARGEAR_VID`, `TS115_PID`, `Kind::TS115`, query registration, human name, id suffix
- `40-opendeck-akp153.rules`: udev rules for `0400:1000`
- `README.md`: supported device list
